### PR TITLE
fix: surface unexpected Brevo API status codes (401/403/429/5xx)

### DIFF
--- a/bruno/subscribeme/Brevo/Add existing contacts to a list.bru
+++ b/bruno/subscribeme/Brevo/Add existing contacts to a list.bru
@@ -21,7 +21,7 @@ headers {
 body:json {
   {
     "emails": [
-      "eliot@rezo-zero.com"
+      "john.doe@contact.com"
     ]
   }
 }

--- a/bruno/subscribeme/Brevo/Get a Contact.bru
+++ b/bruno/subscribeme/Brevo/Get a Contact.bru
@@ -1,0 +1,29 @@
+meta {
+  name: Get a Contact
+  type: http
+  seq: 6
+}
+
+get {
+  url: {{brevo_base_url}}/v3/contacts/:identifier?startDate=&endDate=
+  body: none
+  auth: none
+}
+
+params:query {
+  ~startDate:
+  ~endDate:
+}
+
+params:path {
+  identifier:
+}
+
+headers {
+  api-key: {{brevo_api_key}}
+}
+
+settings {
+  encodeUrl: true
+  timeout: 0
+}

--- a/bruno/subscribeme/Brevo/Get a list's details.bru
+++ b/bruno/subscribeme/Brevo/Get a list's details.bru
@@ -1,0 +1,24 @@
+meta {
+  name: Get a list's details
+  type: http
+  seq: 7
+}
+
+get {
+  url: {{brevo_base_url}}/v3/contacts/lists/:listId
+  body: none
+  auth: none
+}
+
+params:path {
+  listId: 4
+}
+
+headers {
+  api-key: {{brevo_api_key}}
+}
+
+settings {
+  encodeUrl: true
+  timeout: 0
+}

--- a/bruno/subscribeme/OxiMailing/Add new contacts into the specified list..bru
+++ b/bruno/subscribeme/OxiMailing/Add new contacts into the specified list..bru
@@ -27,7 +27,7 @@ auth:basic {
 body:json {
   {
     "contacts" : {
-      "email@rezo-zero.com": {
+      "email@test.com": {
         "firstName": "firstName",
         "lastName": "lastName"
       }

--- a/src/SubscribeMe/Exception/ApiResponseException.php
+++ b/src/SubscribeMe/Exception/ApiResponseException.php
@@ -8,7 +8,7 @@ use Throwable;
 
 final class ApiResponseException extends \RuntimeException
 {
-    public function __construct(private array $responseBody, private ?int $statusCode = null, Throwable $previous = null)
+    public function __construct(private array $responseBody, ?Throwable $previous = null, private ?int $statusCode = null)
     {
         parent::__construct('Api response error', 0, $previous);
     }

--- a/src/SubscribeMe/Exception/ApiResponseException.php
+++ b/src/SubscribeMe/Exception/ApiResponseException.php
@@ -8,7 +8,7 @@ use Throwable;
 
 final class ApiResponseException extends \RuntimeException
 {
-    public function __construct(private array $responseBody, Throwable $previous = null)
+    public function __construct(private array $responseBody, private ?int $statusCode = null, Throwable $previous = null)
     {
         parent::__construct('Api response error', 0, $previous);
     }
@@ -16,5 +16,10 @@ final class ApiResponseException extends \RuntimeException
     public function getResponseBody(): array
     {
         return $this->responseBody;
+    }
+
+    public function getStatusCode(): ?int
+    {
+        return $this->statusCode;
     }
 }

--- a/src/SubscribeMe/Subscriber/BrevoSubscriber.php
+++ b/src/SubscribeMe/Subscriber/BrevoSubscriber.php
@@ -84,7 +84,7 @@ class BrevoSubscriber extends AbstractSubscriber
     }
 
     /**
-     * @throws JsonException
+     * @throws JsonException|ApiResponseException
      */
     protected function doSubscribe(string $uri, array $body): bool|int
     {

--- a/src/SubscribeMe/Subscriber/BrevoSubscriber.php
+++ b/src/SubscribeMe/Subscriber/BrevoSubscriber.php
@@ -4,13 +4,11 @@ declare(strict_types=1);
 
 namespace SubscribeMe\Subscriber;
 
-use JsonException;
 use Psr\Http\Client\ClientExceptionInterface;
 use SubscribeMe\Exception\ApiResponseException;
 use SubscribeMe\Exception\CannotSendTransactionalEmailException;
 use SubscribeMe\Exception\CannotSubscribeException;
 use SubscribeMe\Exception\ApiCredentialsException;
-use SubscribeMe\Exception\UnsupportedUnsubscribePlatformException;
 use SubscribeMe\GDPR\UserConsent;
 use SubscribeMe\ValueObject\EmailAddress;
 
@@ -84,7 +82,7 @@ class BrevoSubscriber extends AbstractSubscriber
     }
 
     /**
-     * @throws JsonException|ApiResponseException
+     * @throws \JsonException|ApiResponseException
      */
     protected function doSubscribe(string $uri, array $body): bool|int
     {
@@ -132,7 +130,7 @@ class BrevoSubscriber extends AbstractSubscriber
              */
             /** @var array $body */
             $body = json_decode($res->getBody()->getContents(), true) ?? [];
-            throw new ApiResponseException($body, $res->getStatusCode());
+            throw new ApiResponseException($body, null, $res->getStatusCode());
         } catch (ClientExceptionInterface $exception) {
             throw new CannotSubscribeException($exception->getMessage(), $exception);
         }
@@ -259,7 +257,7 @@ class BrevoSubscriber extends AbstractSubscriber
              */
             /** @var array $body */
             $body = json_decode($res->getBody()->getContents(), true) ?? [];
-            throw new ApiResponseException($body, $res->getStatusCode());
+            throw new ApiResponseException($body, null, $res->getStatusCode());
         } catch (ClientExceptionInterface $exception) {
             throw new CannotSubscribeException($exception->getMessage(), $exception);
         }

--- a/src/SubscribeMe/Subscriber/BrevoSubscriber.php
+++ b/src/SubscribeMe/Subscriber/BrevoSubscriber.php
@@ -122,12 +122,20 @@ class BrevoSubscriber extends AbstractSubscriber
                     $body['message'] == 'Contact already exist') {
                     return true;
                 }
+
+                return false;
             }
+
+            /*
+             * Any other status code (401, 403, 429, 5xx…) is an unexpected error: do not fail
+             * silently, surface the status code and response body so the caller can diagnose it.
+             */
+            /** @var array $body */
+            $body = json_decode($res->getBody()->getContents(), true) ?? [];
+            throw new ApiResponseException($body, $res->getStatusCode());
         } catch (ClientExceptionInterface $exception) {
             throw new CannotSubscribeException($exception->getMessage(), $exception);
         }
-
-        return false;
     }
 
     /**
@@ -241,11 +249,19 @@ class BrevoSubscriber extends AbstractSubscriber
                 if (isset($body['success'])) {
                     return true;
                 }
+
+                return false;
             }
+
+            /*
+             * Any other status code (401, 403, 429, 5xx…) is an unexpected error: do not fail
+             * silently, surface the status code and response body so the caller can diagnose it.
+             */
+            /** @var array $body */
+            $body = json_decode($res->getBody()->getContents(), true) ?? [];
+            throw new ApiResponseException($body, $res->getStatusCode());
         } catch (ClientExceptionInterface $exception) {
             throw new CannotSubscribeException($exception->getMessage(), $exception);
         }
-
-        return false;
     }
 }

--- a/src/SubscribeMe/Subscriber/ResponseValidationTrait.php
+++ b/src/SubscribeMe/Subscriber/ResponseValidationTrait.php
@@ -16,6 +16,6 @@ trait ResponseValidationTrait
         }
         /** @var array $result */
         $result = json_decode($response->getBody()->getContents(), true);
-        throw new ApiResponseException($result);
+        throw new ApiResponseException($result, $response->getStatusCode());
     }
 }

--- a/src/SubscribeMe/Subscriber/ResponseValidationTrait.php
+++ b/src/SubscribeMe/Subscriber/ResponseValidationTrait.php
@@ -16,6 +16,6 @@ trait ResponseValidationTrait
         }
         /** @var array $result */
         $result = json_decode($response->getBody()->getContents(), true);
-        throw new ApiResponseException($result, $response->getStatusCode());
+        throw new ApiResponseException($result, null, $response->getStatusCode());
     }
 }

--- a/src/SubscribeMe/Subscriber/SubscriberInterface.php
+++ b/src/SubscribeMe/Subscriber/SubscriberInterface.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace SubscribeMe\Subscriber;
 
 use JsonException;
+use SubscribeMe\Exception\ApiResponseException;
 use SubscribeMe\Exception\UnsupportedTransactionalEmailPlatformException;
 use SubscribeMe\Exception\UnsupportedUnsubscribePlatformException;
 use SubscribeMe\GDPR\UserConsent;
@@ -25,14 +26,14 @@ interface SubscriberInterface
      * @param array       $options
      * @param UserConsent[] $userConsents
      * @return bool|int Contact ID if succeeded or false
-     * @throws JsonException
+     * @throws JsonException|ApiResponseException
      */
     public function subscribe(string $email, array $options, array $userConsents = []): bool|int;
 
     /**
      * @param string $email
      * @return bool true on succeeded or false
-     * @throws JsonException|UnsupportedUnsubscribePlatformException
+     * @throws JsonException|UnsupportedUnsubscribePlatformException|ApiResponseException
      */
     public function unsubscribe(string $email): bool;
 

--- a/tests/BrevoMailerTest.php
+++ b/tests/BrevoMailerTest.php
@@ -10,6 +10,7 @@ use JsonException;
 use Nyholm\Psr7\Response;
 use PHPUnit\Framework\TestCase;
 use SubscribeMe\Exception\ApiCredentialsException;
+use SubscribeMe\Exception\ApiResponseException;
 use SubscribeMe\Exception\CannotSendTransactionalEmailException;
 use SubscribeMe\Subscriber\BrevoSubscriber;
 use SubscribeMe\ValueObject\EmailAddress;
@@ -158,6 +159,56 @@ class BrevoMailerTest extends TestCase
         $this->assertEquals('POST', $requests[0]->getMethod());
         $this->assertJsonStringEqualsJsonString($body ?: '{}', $content);
         $this->assertEquals('api.brevo.com', $requests[0]->getUri()->getHost());
+    }
+
+    /**
+     * @throws JsonException
+     */
+    public function testSubscribeThrowsOnUnauthorized(): void
+    {
+        $client = new Client();
+        $factory = new Psr17Factory();
+
+        $client->setDefaultResponse(
+            new Response(401, [], json_encode(['message' => 'IP address not authorized'], JSON_THROW_ON_ERROR))
+        );
+
+        $brevoSubscriber = new BrevoSubscriber($client, $factory, $factory);
+        $brevoSubscriber->setContactListId('3,5');
+        $brevoSubscriber->setApiKey('928f601b-5476-4480-8eb0-c8d979f3b68f');
+
+        try {
+            $brevoSubscriber->subscribe('elly@example.com', []);
+            $this->fail('Expected ApiResponseException was not thrown.');
+        } catch (ApiResponseException $exception) {
+            $this->assertSame(401, $exception->getStatusCode());
+            $this->assertSame('IP address not authorized', $exception->getResponseBody()['message']);
+        }
+    }
+
+    /**
+     * @throws JsonException
+     */
+    public function testUnsubscribeThrowsOnUnauthorized(): void
+    {
+        $client = new Client();
+        $factory = new Psr17Factory();
+
+        $client->setDefaultResponse(
+            new Response(401, [], json_encode(['message' => 'IP address not authorized'], JSON_THROW_ON_ERROR))
+        );
+
+        $brevoSubscriber = new BrevoSubscriber($client, $factory, $factory);
+        $brevoSubscriber->setContactListId('3');
+        $brevoSubscriber->setApiKey('928f601b-5476-4480-8eb0-c8d979f3b68f');
+
+        try {
+            $brevoSubscriber->unsubscribe('elly@example.com');
+            $this->fail('Expected ApiResponseException was not thrown.');
+        } catch (ApiResponseException $exception) {
+            $this->assertSame(401, $exception->getStatusCode());
+            $this->assertSame('IP address not authorized', $exception->getResponseBody()['message']);
+        }
     }
 
     /**


### PR DESCRIPTION
Closes #5 
Throw ApiResponseException with the status code and response body instead of silently returning false, so callers can diagnose failures like a 401 caused by a non-whitelisted server IP.